### PR TITLE
Ensure complete value match appears first in the suggestion list.

### DIFF
--- a/src/js/autocomplete-choice-input.js
+++ b/src/js/autocomplete-choice-input.js
@@ -343,7 +343,9 @@
                 this.autocompleteList.hide();
             }
 
-            if (this.options.allowAdd && typeof values[this.input.val()] === "undefined") {
+            var isInputCompleteValue = typeof values[this.input.val()] !== "undefined";
+
+            if (this.options.allowAdd && !isInputCompleteValue) {
                 var addLi = $("<li>");
                 addLi.attr("id", this.input.val());
                 addLi.text(this.options.addText.replace("%item%", this.input.val()));
@@ -359,7 +361,11 @@
 
                     li.on("click", this.suggestedItemClickCallback(li));
 
-                    this.autocompleteList.append(li);
+                    if (isInputCompleteValue && values[key] === this.input.val()) {
+                        this.autocompleteList.prepend(li);
+                    } else {
+                        this.autocompleteList.append(li);
+                    }
                 }
             }
         },


### PR DESCRIPTION
This commit ensures that complete value match will appear first in the suggestion list. This should improve user experience in general, and fix the following bug:
Consider a suggestion list with values "102/6" and "2/6". Inputting "2/6" and hitting enter can actually cause value "102/6" to be directly selected (since we are in direct match mode, but "102/6" is sorted before "2/6" in the suggestion list). This is very likely not what the user wants or expects to happen.